### PR TITLE
Added command to switch back and forth between two buffers.

### DIFF
--- a/autoload/buffer_history.vim
+++ b/autoload/buffer_history.vim
@@ -11,6 +11,7 @@ function! buffer_history#add(bufnr) abort "{{{1
   let bufinfo = getbufinfo(a:bufnr)[0]
   if !bufinfo['listed'] || empty(trim(bufname(a:bufnr))) | return | endif
 
+  let w:buffer_history_last_jump_direction = 1
   let index = w:buffer_history_index + 1
   if bufexists(a:bufnr)
     let bindex = index(w:buffer_history, a:bufnr)
@@ -55,6 +56,17 @@ function! buffer_history#jump(...) abort "{{{1
     endif
   endif
   echo 'Reached' (dirn > 0 ? 'end' : 'start') 'of buffer history'
+endfunction
+
+
+function! buffer_history#switch() abort "{{{1
+  if !exists('w:buffer_history') | return | endif
+
+  if !exists('w:buffer_history_last_jump_direction')
+    let w:buffer_history_last_jump_direction = 1
+  endif
+  call buffer_history#jump(w:buffer_history_last_jump_direction * -1)
+  let w:buffer_history_last_jump_direction *= -1
 endfunction
 
 function! buffer_history#list() abort "{{{1

--- a/plugin/buffer_history.vim
+++ b/plugin/buffer_history.vim
@@ -11,6 +11,7 @@ augroup BufferHistory
 augroup END
 
 command! BufferHistoryList call buffer_history#list()
+command! BufferHistorySwitch call buffer_history#switch()
 command! -count=1 BufferHistoryBack call buffer_history#jump()
 command! -count=1 BufferHistoryForward call buffer_history#jump(1)
 

--- a/plugin/buffer_history.vim
+++ b/plugin/buffer_history.vim
@@ -7,7 +7,7 @@ augroup BufferHistory
   au!
 
   autocmd BufWinEnter * call buffer_history#add(winbufnr(0))
-  autocmd BufWipeout * call buffer_history#remove(bufnr('<afile>'))
+" autocmd BufWipeout * call buffer_history#remove(bufnr('<afile>'))
 augroup END
 
 command! BufferHistoryList call buffer_history#list()


### PR DESCRIPTION
I sometimes find it useful to switch back and forth between the same two buffers -- usually I edit one and just read the other. 

I think(?) it's not currently possible to have this workflow using a single command, hence I added a specialized function that does what I wanted. 

Let me know what you think.